### PR TITLE
chore: upgraded to well-rested-client 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.lindar</groupId>
     <artifactId>loqate-client</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <name>Loqate Java Client</name>
     <description>Java client that uses the Loqate cloud address API</description>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.lindar</groupId>
             <artifactId>well-rested-client</artifactId>
-            <version>2.0.0</version>
+            <version>2.3.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/lindar/loqate/util/RequestFactory.java
+++ b/src/main/java/com/lindar/loqate/util/RequestFactory.java
@@ -5,6 +5,11 @@ import com.lindar.wellrested.vo.WellRestedResponse;
 
 public class RequestFactory {
     public WellRestedResponse makeRequest(String path) {
-        return WellRestedRequest.builder().url(path).build().post().submit();
+        return WellRestedRequest.builder()
+                                .url(path)
+                                .build()
+                                .post()
+                                .jsonContent("") // this ensures 'Content-Length: 0' header gets added to the request
+                                .submit();
     }
 }


### PR DESCRIPTION
**Notes:**
- `httpclient 5.x` does not send `Content-Length: 0` header when POST an empty body is sent therefore a workaround is needed (empty string in body)